### PR TITLE
Require PHP 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
 
     "require": {
-        "php": ">=5.3.8",
+        "php": "^5.3.8",
         "twilio/sdk": "dev-master",
         "guzzlehttp/guzzle": "~4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -23,7 +23,7 @@
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/streams": "~1.4",
-                "php": ">=5.4.0"
+                "php": "^5.4.0"
             },
             "require-dev": {
                 "ext-curl": "*",


### PR DESCRIPTION
Previous rules allowed Heroku to deploy with PHP 7, which is not compatible with this code.